### PR TITLE
add static load balancer ip

### DIFF
--- a/running/main-load-balancer.yml
+++ b/running/main-load-balancer.yml
@@ -8,6 +8,7 @@ metadata:
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
+  loadBalancerIP: 35.233.220.107
   ports:
    - port: 80
   selector:

--- a/running/main-load-balancer.yml
+++ b/running/main-load-balancer.yml
@@ -8,6 +8,8 @@ metadata:
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
+  # This ip was specifically reserved in GCP for the main mvp studio k8 cluster
+  # If this resource gets deleted and re-created this should ensure it comes back with the same static ip
   loadBalancerIP: 35.233.220.107
   ports:
    - port: 80


### PR DESCRIPTION
the load balancer IP was listed as 'ephemeral', I switched it static and configured it in the yaml, so if the load balancer gets destroyed it should pick up the same static ip