### PR TITLE
Fixed openeugene routing and added routing for eugenefoodscene

### DIFF
--- a/docs/AMBASSADOR.md
+++ b/docs/AMBASSADOR.md
@@ -23,6 +23,31 @@ a [Lets Encrypt](https://letsencrypt.org/) cert for that host using an
 Again a good example is 
 [the host resource for the mvpstudio website]((../running/ambassador-edge/routing/mvpstudio-org/prod.yml)).
 
+Note that it takes about 60 seconds for the certificate to get issued for new `Host` records so be patient. Also,
+if there are issues you can directly fetch any Ambassador custom resource definition, including the `Host` records and
+these give you status info, can be deleted, etc. For example:
+
+```
+$ kubectl get -n ambassador-edge host
+NAME                             HOSTNAME                                   STATE   PHASE COMPLETED      PHASE PENDING              AGE
+eugene-food-scene-dns-host       eugenefoodscene.com                        Error   ACMEUserRegistered   ACMECertificateChallenge   23h
+eugene-food-scene-dns-www-host   www.eugenefoodscene.com                    Error   ACMEUserRegistered   ACMECertificateChallenge   8h
+eugene-food-scene-prod-host      eugenefoodscene.prod.apps.mvpstudio.org    Ready                                                   23h
+eugene-food-scene-stage-host     eugenefoodscene.stage.apps.mvpstudio.org   Ready                                                   23h
+little-help-book-stage-host      littlehelpbook.stage.apps.mvpstudio.org    Ready                                                   20d
+openeugene-prod-host             openeugene.org                             Ready                                                   8h
+openeugene-prod-mvp-host         openeugene.prod.apps.mvpstudio.org         Ready                                                   2d3h
+openeugene-prod-www-host         www.openeugene.org                         Ready                                                   8h
+openeugene-stage-mvp-host        openeugene.stage.apps.mvpstudio.org        Ready                                                   2d3h
+prod-mvpstudio-org               mvpstudio.org                              Ready                                                   22d
+prod-www-mvpstudio-org           www.mvpstudio.org                          Ready                                                   21d
+```
+
+Shows all the `Host` records that Ambassador is aware of and their status. Here we can see that the SSL certs for
+`eugenefoodscene.com` and `www.eugenefoodscene.com` had errors. In this particular case that was because there were
+initial DNS errors so the initial SSL cert attempt failed. To fix it you can `kubectl delete -n ambassador-edge host
+eugene-food-scene-dns-host` and then re-apply the file that created the `Host` record to cause it to retry.
+
 
 ## Debugging
 

--- a/running/ambassador-edge/routing/eugene-food-scene/prod.yml
+++ b/running/ambassador-edge/routing/eugene-food-scene/prod.yml
@@ -8,6 +8,7 @@ spec:
   host: eugenefoodscene.prod.apps.mvpstudio.org
   prefix: /
   service: eugene-food-scene-web.eugene-food-scene-prod
+  use_websocket: true
 ---
 apiVersion: getambassador.io/v2
 kind: Host
@@ -28,6 +29,7 @@ spec:
   host: eugenefoodscene.com
   prefix: /
   service: eugene-food-scene-web.eugene-food-scene-prod
+  use_websocket: true
 ---
 # Redirect www to non-www
 apiVersion: getambassador.io/v2

--- a/running/ambassador-edge/routing/eugene-food-scene/prod.yml
+++ b/running/ambassador-edge/routing/eugene-food-scene/prod.yml
@@ -36,9 +36,9 @@ metadata:
   name: eugene-food-scene-www-dns-mapping
   namespace: ambassador-edge
 spec:
-  host: www.eugenefoodscene.org
+  host: www.eugenefoodscene.com
   prefix: /
-  service: eugenefoodscene.org
+  service: eugenefoodscene.com
   host_redirect: true
 ---
 apiVersion: getambassador.io/v2
@@ -47,6 +47,16 @@ metadata:
   name: eugene-food-scene-dns-host
   namespace: ambassador-edge
 spec:
-  hostname: eugenefoodscene.org
+  hostname: eugenefoodscene.com
+  acmeProvider:
+    email: mvpstudiooregon@gmail.com
+---
+apiVersion: getambassador.io/v2
+kind: Host
+metadata:
+  name: eugene-food-scene-dns-www-host
+  namespace: ambassador-edge
+spec:
+  hostname: www.eugenefoodscene.com
   acmeProvider:
     email: mvpstudiooregon@gmail.com

--- a/running/ambassador-edge/routing/eugene-food-scene/prod.yml
+++ b/running/ambassador-edge/routing/eugene-food-scene/prod.yml
@@ -2,51 +2,51 @@
 apiVersion: getambassador.io/v2
 kind: Mapping
 metadata:
-  name: openeugene-prod-mvp-mapping
+  name: eugene-food-scene-prod-mapping
   namespace: ambassador-edge
 spec:
-  host: openeugene.prod.apps.mvpstudio.org
+  host: eugenefoodscene.prod.apps.mvpstudio.org
   prefix: /
-  service: openeugene-marketing-web.openeugene-marketing-prod
+  service: eugene-food-scene-web.eugene-food-scene-prod
 ---
 apiVersion: getambassador.io/v2
 kind: Host
 metadata:
-  name: openeugene-prod-mvp-host
+  name: eugene-food-scene-prod-host
   namespace: ambassador-edge
 spec:
-  hostname: openeugene.prod.apps.mvpstudio.org
+  hostname: eugenefoodscene.prod.apps.mvpstudio.org
   acmeProvider:
     email: mvpstudiooregon@gmail.com
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
 metadata:
-  name: openeugene-prod-mapping
+  name: eugene-food-scene-bare-dns-mapping
   namespace: ambassador-edge
 spec:
-  host: openeugene.org
+  host: eugenefoodscene.com
   prefix: /
-  service: openeugene-marketing-web.openeugene-marketing-prod
+  service: eugene-food-scene-web.eugene-food-scene-prod
 ---
 # Redirect www to non-www
 apiVersion: getambassador.io/v2
 kind: Mapping
 metadata:
-  name: openeugene-prod-www-mapping
+  name: eugene-food-scene-www-dns-mapping
   namespace: ambassador-edge
 spec:
-  host: www.openeugene.org
+  host: www.eugenefoodscene.org
   prefix: /
-  service: openeugene.org
+  service: eugenefoodscene.org
   host_redirect: true
 ---
 apiVersion: getambassador.io/v2
 kind: Host
 metadata:
-  name: openeugene-prod-host
+  name: eugene-food-scene-dns-host
   namespace: ambassador-edge
 spec:
-  hostname: openeugene.org
+  hostname: eugenefoodscene.org
   acmeProvider:
     email: mvpstudiooregon@gmail.com

--- a/running/ambassador-edge/routing/eugene-food-scene/stage.yml
+++ b/running/ambassador-edge/routing/eugene-food-scene/stage.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: eugene-food-scene-stage-mapping
+  namespace: ambassador-edge
+spec:
+  host: eugenefoodscene.stage.apps.mvpstudio.org
+  prefix: /
+  service: eugene-food-scene-web.eugene-food-scene-stage
+---
+apiVersion: getambassador.io/v2
+kind: Host
+metadata:
+  name: eugene-food-scene-stage-host
+  namespace: ambassador-edge
+spec:
+  hostname: eugenefoodscene.stage.apps.mvpstudio.org
+  acmeProvider:
+    email: mvpstudiooregon@gmail.com

--- a/running/ambassador-edge/routing/eugene-food-scene/stage.yml
+++ b/running/ambassador-edge/routing/eugene-food-scene/stage.yml
@@ -8,6 +8,7 @@ spec:
   host: eugenefoodscene.stage.apps.mvpstudio.org
   prefix: /
   service: eugene-food-scene-web.eugene-food-scene-stage
+  use_websocket: true
 ---
 apiVersion: getambassador.io/v2
 kind: Host

--- a/running/ambassador-edge/routing/little-help-book/stage.yml
+++ b/running/ambassador-edge/routing/little-help-book/stage.yml
@@ -9,6 +9,7 @@ spec:
   prefix: /
   # rewrite: /weatherforecast
   service: little-help-book-web.little-help-book-stage
+  use_websocket: true
 ---
 apiVersion: getambassador.io/v2
 kind: Host

--- a/running/ambassador-edge/routing/openeugene/prod.yml
+++ b/running/ambassador-edge/routing/openeugene/prod.yml
@@ -50,3 +50,13 @@ spec:
   hostname: openeugene.org
   acmeProvider:
     email: mvpstudiooregon@gmail.com
+---
+apiVersion: getambassador.io/v2
+kind: Host
+metadata:
+  name: openeugene-prod-www-host
+  namespace: ambassador-edge
+spec:
+  hostname: www.openeugene.org
+  acmeProvider:
+    email: mvpstudiooregon@gmail.com


### PR DESCRIPTION
openeugene needed a www redirect.

eugenefoodscene doesn't work yet as the pods and services don't exist yet but these are the pods, service, and DNS names agreed to with @nohorse and @codegold79 .