### PR TITLE
set rook-ceph-block as default storage class

### DIFF
--- a/running/ceph/storageclass.yml
+++ b/running/ceph/storageclass.yml
@@ -11,24 +11,26 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-   name: rook-ceph-block
+  name: rook-ceph-block
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
-    clusterID: rook-ceph
-    pool: replicapool
+  clusterID: rook-ceph
+  pool: replicapool
 
-    # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-    imageFeatures: layering
+  # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
+  imageFeatures: layering
 
-    # The secrets contain Ceph admin credentials.
-    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+  # The secrets contain Ceph admin credentials.
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
 
-    # Specify the filesystem type of the volume. If not specified, csi-provisioner
-    # will set default as `ext4`.
-    csi.storage.k8s.io/fstype: ext4
+  # Specify the filesystem type of the volume. If not specified, csi-provisioner
+  # will set default as `ext4`.
+  csi.storage.k8s.io/fstype: ext4
 
 # Delete the rbd volume when a PVC is deleted
 reclaimPolicy: Delete


### PR DESCRIPTION
apparently my editor decided to fix some indentation, but the real change here is this:
```
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
```

Now a persistent volume claim does not need to request a specific storage class, it will default to the only one we currently have `rook-ceph-block`.