### PR TITLE
update amabassador edge to fix ssl issues

### DIFF
--- a/running/ambassador-edge/aes.yaml
+++ b/running/ambassador-edge/aes.yaml
@@ -282,7 +282,7 @@ spec:
               value: https://127.0.0.1:8443
             - name: AMBASSADOR_ADMIN_URL
               value: http://127.0.0.1:8877
-          image: quay.io/datawire/aes:1.3.1
+          image: quay.io/datawire/aes:1.4.3
           imagePullPolicy: Always
           name: aes
           ports:


### PR DESCRIPTION
Looks like ambassador does some leader election to figure out which node should be updating certs and maybe it was just having problems. I tried just kicking all the pods first and it didn't fix the issue. I updated the version, it got a bit hung waiting to claim the acme client leadership for a while, I kicked the pod that did have it, the deployment finished, certs got refreshed (I think they may have already been refreshed but the secrets weren't updated?), and things are working. Do I fully understand it? No, is it working? Yes. 🍸 