### PR TITLE
Create prod.yml

### DIFF
--- a/running/ambassador-edge/routing/bring-recycling/prod.yml
+++ b/running/ambassador-edge/routing/bring-recycling/prod.yml
@@ -1,0 +1,30 @@
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: bring-recycling-node-mapping
+  namespace: ambassador-edge
+spec:
+  host: bringrecycling.mvpstudio.org
+  prefix: /api
+  service: bring-recycling-webserver.prod-bring-recycling
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: bring-recycling-react-mapping
+  namespace: ambassador-edge
+spec:
+  host: bringrecycling.mvpstudio.org
+  prefix: /
+  service: bring-recycling-react.prod-bring-recycling
+---
+apiVersion: getambassador.io/v2
+kind: Host
+metadata:
+  name: bring-recycling-host
+  namespace: ambassador-edge
+spec:
+  hostname: bringrecycling.mvpstudio.org
+  acmeProvider:
+    email: mvpstudiooregon@gmail.com
+---

--- a/running/ambassador-edge/routing/bring-recycling/prod.yml
+++ b/running/ambassador-edge/routing/bring-recycling/prod.yml
@@ -26,5 +26,5 @@ metadata:
 spec:
   hostname: bringrecycling.mvpstudio.org
   acmeProvider:
-    email: mvpstudiooregon@gmail.com
+    email: mvpstudiooregon+bringrecycling@gmail.com
 ---


### PR DESCRIPTION
Routing file for bring-recycling project. Aims to direct all traffic going to the bringrecycling.mvpstudio.org/api URL to the bring-recycling-webserver, and all other bringrecycling.mvpstudio.org traffic to the bring-recycling-react service.