### PR TITLE
Make sure wireguard auto-starts on boot.

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -61,6 +61,11 @@
        tags:
           - wg_config
        become: yes
+     - name: enable wireguard for auto-start on boot
+       command: sudo systemctl enable wg-quick@wg0.service
+       tags:
+          - wg_config
+       become: yes
      # Have to use command here because the systemd module will fail as wg-quick@wg0 isn't a real unit
      - name: start the wireguard service
        command: systemctl restart wg-quick@wg0


### PR DESCRIPTION
Wireguard was set up but not to auto-start on boot. Now 'tis.

In Slack I'd said the config file had gone missing but that wasn't correct - it just was only readable by root (correctly) so I didn't see it so that's good.