### PR TITLE
Added rewrite to bring-recycling-node-mapping

### DIFF
--- a/running/ambassador-edge/routing/bring-recycling/prod.yml
+++ b/running/ambassador-edge/routing/bring-recycling/prod.yml
@@ -6,6 +6,7 @@ metadata:
 spec:
   host: bringrecycling.mvpstudio.org
   prefix: /api
+  rewrite: /api
   service: bring-recycling-webserver.prod-bring-recycling:5000
 ---
 apiVersion: getambassador.io/v2


### PR DESCRIPTION
By default ambassador was rewriting the prefix /api to /, adding "rewrite: /api" preserves the original URL so the right routes respond to requests.